### PR TITLE
Update response status using http status codes

### DIFF
--- a/list/server/server.go
+++ b/list/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"log"
+	"net/http"
 
 	"github.com/wizelineacademy/GoWorkshop/proto/list"
 	"github.com/wizelineacademy/GoWorkshop/shared"
@@ -19,10 +20,10 @@ func (s *Server) CreateItem(ctx context.Context, in *list.CreateItemRequest) (*l
 
 		response.Id = itemID
 		response.Message = "Item created successfully"
-		response.Code = 200
+		response.Code = http.StatusCreated
 	} else {
 		response.Message = err.Error()
-		response.Code = 500
+		response.Code = http.StatusInternalServerError
 	}
 
 	return response, err
@@ -33,7 +34,7 @@ func (s *Server) GetUserItems(ctx context.Context, in *list.GetUserItemsRequest)
 
 	response := &list.GetUserItemsResponse{
 		Items: items,
-		Code:  200,
+		Code:  http.StatusOK,
 	}
 
 	return response, nil
@@ -47,10 +48,10 @@ func (s *Server) DeleteItem(ctx context.Context, in *list.DeleteItemRequest) (*l
 		log.Printf("[item.Delete] Deleted item ID: %s", in.Id)
 
 		response.Message = "Item deleted successfully"
-		response.Code = 200
+		response.Code = http.StatusOK
 	} else {
 		response.Message = err.Error()
-		response.Code = 500
+		response.Code = http.StatusInternalServerError
 	}
 
 	return response, err

--- a/users/server/server.go
+++ b/users/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"log"
+	"net/http"
 
 	"github.com/wizelineacademy/GoWorkshop/proto/list"
 	"github.com/wizelineacademy/GoWorkshop/proto/users"
@@ -24,10 +25,10 @@ func (s *Server) CreateUser(ctx context.Context, in *users.CreateUserRequest) (*
 
 		response.Message = "User created successfully"
 		response.Id = userID
-		response.Code = 200
+		response.Code = http.StatusCreated
 	} else {
 		response.Message = err.Error()
-		response.Code = 500
+		response.Code = http.StatusInternalServerError
 	}
 
 	return response, err

--- a/web/pkg/web/pages.go
+++ b/web/pkg/web/pages.go
@@ -80,7 +80,7 @@ func (c *Context) createUser(w web.ResponseWriter, r *web.Request) {
 	resp, err := c.UsersService.CreateUser(context.Background(), &pbUsers.CreateUserRequest{
 		Email: email,
 	})
-	if err == nil && resp != nil && resp.Code == 200 {
+	if err == nil && resp != nil && resp.Code == http.StatusCreated {
 		http.Redirect(w, r.Request, "/user/"+resp.GetId(), http.StatusFound)
 		return
 	}


### PR DESCRIPTION
This patch unifies the response status code using only the
const from the http package for avoiding having hardcoded integers.

Signed-off-by: Marcela Bonell <marcelabonell@gmail.com>